### PR TITLE
Fix #8: cyrillic product name raise UnicodeEncodeError.

### DIFF
--- a/paymentwall/base.py
+++ b/paymentwall/base.py
@@ -84,5 +84,5 @@ class Paymentwall:
 	@classmethod
 	def hash(cls, string, library_type):
 		hashed_string = hashlib.md5() if library_type == 'md5' else hashlib.sha256()
-		hashed_string.update(string.encode())
+		hashed_string.update(string)
 		return hashed_string.hexdigest()

--- a/paymentwall/product.py
+++ b/paymentwall/product.py
@@ -31,7 +31,10 @@ class Product:
 		return self.currency_code
 
 	def get_name(self):
-		return self.name
+		if self.name:
+			return self.name.encode('utf-8')
+
+		return None
 
 	def get_type(self):
 		return self.product_type


### PR DESCRIPTION
Tested with the following languages: Ukrainian, Russian, English, Japanese, Turkish, Finnish. You should always set a product name in Unicode.
